### PR TITLE
[chore] 배포를 위한 깃헙액션 추가

### DIFF
--- a/.github/workflows/repostiory_dispatch.yaml
+++ b/.github/workflows/repostiory_dispatch.yaml
@@ -1,0 +1,26 @@
+name: Dispatch to Forked Repository
+
+on:
+  push:
+
+jobs:
+  print:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Get the refs
+        run: echo "[log] ref is ${{github.ref}}"
+      - name: Get the branch name
+        run: echo "[log] Branch name is ${{github.ref_name}}"
+
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        run: |
+          curl -L \
+          -X POST https://api.github.com/repos/${{vars.DEPLOY_REPO_PATH}}/dispatches \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.DEPLOY_REPO_ACCESS_TOKEN}}" \
+          -d '{"event_type": "sync", "client_payload": {"target_branch": "chore/action/ignore-action"}}'


### PR DESCRIPTION
## 스크린샷
-
## Motivation

aws로 넘어가기 전까진(시연 전까진) vercel로 배포를 하고자 하는데, organization 저장소에 등록하려면 과금해야하는 팀 계정이 필요해서, 제 개인 레포지토리에 fork 뜬 뒤 push 이벤트가 일어날 때마다 포크뜬 레포지토리로 repostory_dispatch 이벤트 전달하는 깃헙 액션을 추가했습니다.



<br>

## To Reviewers

- 

### Key Changes

- 
