### PR TITLE
[feat] 회원 가입시 다음 입력창 focus하도록 추가

### DIFF
--- a/src/app/register/shelter/components/Account.tsx
+++ b/src/app/register/shelter/components/Account.tsx
@@ -26,7 +26,8 @@ export default function Account({ onNext }: OnNextProps) {
     register,
     formState: { errors },
     watch,
-    setError
+    setError,
+    setFocus
   } = useFormContext();
 
   const emailValue = watch('email');
@@ -44,6 +45,10 @@ export default function Account({ onNext }: OnNextProps) {
       debouncedValidator(emailValue, 'EMAIL');
     }
   }, [emailValue, debouncedValidator]);
+
+  useEffect(() => {
+    setFocus('email');
+  }, []);
 
   const areInputsFilled =
     Boolean(emailValue?.trim()) &&

--- a/src/app/register/shelter/components/Address.tsx
+++ b/src/app/register/shelter/components/Address.tsx
@@ -4,18 +4,22 @@ import EmphasizedTitle, {
 } from '@/components/common/EmphasizedTitle/EmphasizedTitle';
 import AddressSearchBar from '@/components/shelter-edit/AddressSearchBar/AddressSearchBar';
 import useHeader from '@/hooks/useHeader';
-import { useCallback, useState } from 'react';
+import { use, useCallback, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { OnNextProps } from '../page';
 import * as styles from './../styles.css';
 import { SearchedAddress } from '@/types/shelter';
 
 export default function Address({ onNext }: OnNextProps) {
-  const { setValue } = useFormContext();
+  const { setValue, setFocus } = useFormContext();
   const setHeader = useHeader({
     thisPage: 3,
     entirePage: 4
   });
+
+  useEffect(() => {
+    setFocus('address[address]');
+  }, []);
 
   const [searchedAddress, setSearchedAddress] = useState<SearchedAddress>();
   const handleChangeAddress = useCallback(

--- a/src/app/register/shelter/components/Description.tsx
+++ b/src/app/register/shelter/components/Description.tsx
@@ -7,15 +7,21 @@ import useHeader from '@/hooks/useHeader';
 import { FieldValues, SubmitHandler, useFormContext } from 'react-hook-form';
 import { OnNextProps } from '../page';
 import * as styles from './../styles.css';
+import { useEffect } from 'react';
 
 export default function Description({ onSubmit }: OnNextProps) {
   const {
     handleSubmit,
     register,
     formState: { errors },
-    watch
+    watch,
+    setFocus
   } = useFormContext();
   const descriptionValue = watch('description');
+
+  useEffect(() => {
+    setFocus('description');
+  }, []);
 
   const setHeader = useHeader({
     thisPage: 4,

--- a/src/app/register/shelter/components/Hp.tsx
+++ b/src/app/register/shelter/components/Hp.tsx
@@ -5,7 +5,7 @@ import EmphasizedTitle, {
 import TextField from '@/components/common/TextField/TextField';
 import useHeader from '@/hooks/useHeader';
 import { formatPhone } from '@/utils/formatInputs';
-import { useCallback } from 'react';
+import { use, useCallback, useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { OnNextProps } from '../page';
 import * as styles from './../styles.css';
@@ -14,7 +14,8 @@ export default function Hp({ onNext }: OnNextProps) {
   const {
     register,
     formState: { errors },
-    watch
+    watch,
+    setFocus
   } = useFormContext();
   const hpValue = watch('phoneNumber');
 
@@ -22,6 +23,10 @@ export default function Hp({ onNext }: OnNextProps) {
     thisPage: 2,
     entirePage: 4
   });
+
+  useEffect(() => {
+    setFocus('phoneNumber');
+  }, []);
 
   const handlePhoneNumberChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/app/register/shelter/components/Name.tsx
+++ b/src/app/register/shelter/components/Name.tsx
@@ -15,7 +15,8 @@ export default function Name({ onNext }: OnNextProps) {
     register,
     formState: { errors },
     watch,
-    setError
+    setError,
+    setFocus
   } = useFormContext();
   const nameValue = watch('name');
 
@@ -36,6 +37,10 @@ export default function Name({ onNext }: OnNextProps) {
       debouncedValidator(nameValue, 'NAME');
     }
   }, [nameValue, debouncedValidator]);
+
+  useEffect(() => {
+    setFocus('name');
+  }, []);
 
   return (
     <>

--- a/src/app/register/shelter/components/SpecificAddress.tsx
+++ b/src/app/register/shelter/components/SpecificAddress.tsx
@@ -7,15 +7,20 @@ import TextField from '@/components/common/TextField/TextField';
 import { useFormContext } from 'react-hook-form';
 import { OnNextProps } from '../page';
 import * as styles from './../styles.css';
+import { useEffect } from 'react';
 
 export default function SpecificAddress({ onNext }: OnNextProps) {
   const {
     register,
     formState: { errors },
-    watch
+    watch,
+    setFocus
   } = useFormContext();
   const addressValue = watch('address[addressDetail]');
 
+  useEffect(() => {
+    setFocus('address[addressDetail]');
+  }, []);
   return (
     <>
       <div className={styles.titleWrapper} style={{ marginBottom: '109px' }}>

--- a/src/app/register/volunteer/[...slug]/ContactNumber.tsx
+++ b/src/app/register/volunteer/[...slug]/ContactNumber.tsx
@@ -3,13 +3,17 @@ import EmphasizedTitle, {
 } from '@/components/common/EmphasizedTitle/EmphasizedTitle';
 import TextField from '@/components/common/TextField/TextField';
 import { formatPhone } from '@/utils/formatInputs';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { CurrentComponentProps } from './CurrentComponentTypes';
 import * as style from './style.css';
 
 export default function ContactNumber({ formName }: CurrentComponentProps) {
-  const { register } = useFormContext();
+  const { register, setFocus } = useFormContext();
+  useEffect(() => {
+    formName && setFocus(formName);
+  }, []);
+
   const handlePhoneNumberChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const value = event.target.value;

--- a/src/app/register/volunteer/[...slug]/NickName.tsx
+++ b/src/app/register/volunteer/[...slug]/NickName.tsx
@@ -4,8 +4,14 @@ import EmphasizedTitle, {
 import * as style from './style.css';
 import TextFieldWithForm from '@/components/common/TextField/TextFieldWithForm';
 import { CurrentComponentProps } from './CurrentComponentTypes';
+import { useEffect } from 'react';
+import { useFormContext } from 'react-hook-form';
 
 export default function NickName({ formName }: CurrentComponentProps) {
+  const { setFocus } = useFormContext();
+  useEffect(() => {
+    formName && setFocus(formName);
+  }, []);
   return (
     <>
       <div className={style.titleSection}>


### PR DESCRIPTION


## Motivation

- [qa 노션 링크](https://www.notion.so/dankim9494/967c704ddebb445ca321481543e95e50)

- 회원가입 플로우에서 페이지 진입시 입력해야할 텍스트필드에 focus하는 기능을 추가했습니다.
- 보호소, 봉사자 모두 적용했습니다.

<br>

## To Reviewers

- 
### Key Changes

- 