### PR TITLE
[Feat] 비밀번호 변경 기능 & QA 반영

### DIFF
--- a/src/api/shelter/admin/useDeleteVolunteerEvent.ts
+++ b/src/api/shelter/admin/useDeleteVolunteerEvent.ts
@@ -4,7 +4,6 @@ import {
   useQueryClient
 } from '@tanstack/react-query';
 import { DeleteResponse, remove } from './volunteer-event';
-import { queryKey } from '../volunteer-event';
 
 export interface DeleteEventPayload extends DeleteResponse {
   shelterId: number;

--- a/src/api/shelter/admin/useUpdateVolunteerEvent.tsx
+++ b/src/api/shelter/admin/useUpdateVolunteerEvent.tsx
@@ -1,0 +1,26 @@
+import {
+  UseMutationOptions,
+  useMutation,
+  useQueryClient
+} from '@tanstack/react-query';
+import { PutResponse, PutVolunteerEventPayload, put } from './volunteer-event';
+
+export interface PutEventPayload extends PutVolunteerEventPayload {
+  eventId: number;
+}
+
+export default function useUpdateVolunteerEvent(
+  options?: UseMutationOptions<PutResponse, unknown, PutEventPayload>
+) {
+  const queryClient = useQueryClient();
+  return useMutation<PutResponse, unknown, PutEventPayload>(
+    ({ eventId, ...payload }) => put(eventId, payload),
+    {
+      onSuccess: (data, variables, context) => {
+        options?.onSuccess && options.onSuccess(data, variables, context);
+        return queryClient.invalidateQueries();
+      },
+      ...options
+    }
+  );
+}

--- a/src/api/shelter/admin/useWriteVolunteerEvent.tsx
+++ b/src/api/shelter/admin/useWriteVolunteerEvent.tsx
@@ -1,0 +1,22 @@
+import {
+  UseMutationOptions,
+  useMutation,
+  useQueryClient
+} from '@tanstack/react-query';
+import { PostResponse, VolunteerEventPayload, post } from './volunteer-event';
+
+export default function useWriteVolunteerEvent(
+  options?: UseMutationOptions<PostResponse, unknown, VolunteerEventPayload>
+) {
+  const queryClient = useQueryClient();
+  return useMutation<PostResponse, unknown, VolunteerEventPayload>(
+    payload => post(payload),
+    {
+      onSuccess: (data, variables, context) => {
+        options?.onSuccess && options.onSuccess(data, variables, context);
+        return queryClient.invalidateQueries();
+      },
+      ...options
+    }
+  );
+}

--- a/src/api/shelter/auth/login.ts
+++ b/src/api/shelter/auth/login.ts
@@ -11,15 +11,23 @@ export type LoginResponse = {
   refreshToken: string;
   needToChangePassword: boolean;
 };
-export interface fowardPwdPayload {
+export interface FowardPwdPayload {
   email: string;
   phoneNumber: string;
 }
 
-export type fowardPwdResponse = {
+export type FowardPwdResponse = {
   shelterUserId: number;
   needToChangePassword: boolean;
 };
+
+export interface PwdChangePayload {
+  password: string;
+}
+export interface PwdChangeResponse {
+  shelterUserId: number;
+  needToChangePassword: boolean;
+}
 
 export const loginShelter = async (data: LoginPayload) => {
   const response = await api
@@ -39,12 +47,22 @@ export const isExist = async (value: string, type: string) => {
   return response;
 };
 
-export const fowardPwdLink = async (data: fowardPwdPayload) => {
+export const fowardPwdLink = async (data: FowardPwdPayload) => {
   const response = await api
     .post(`auth/shelter/reset-password`, {
       json: data
     })
-    .then(res => res.json<fowardPwdResponse>());
+    .then(res => res.json<FowardPwdResponse>());
+
+  return response;
+};
+
+export const pwdChange = async (data: PwdChangePayload) => {
+  const response = await api
+    .post(`auth/shelter/change-password`, {
+      json: data
+    })
+    .then(res => res.json<PwdChangeResponse>());
 
   return response;
 };

--- a/src/api/shelter/auth/login.ts
+++ b/src/api/shelter/auth/login.ts
@@ -9,6 +9,16 @@ export interface LoginPayload {
 export type LoginResponse = {
   accessToken: string;
   refreshToken: string;
+  needToChangePassword: boolean;
+};
+export interface fowardPwdPayload {
+  email: string;
+  phoneNumber: string;
+}
+
+export type fowardPwdResponse = {
+  shelterUserId: number;
+  needToChangePassword: boolean;
 };
 
 export const loginShelter = async (data: LoginPayload) => {
@@ -25,6 +35,16 @@ export const isExist = async (value: string, type: string) => {
   const response = await api
     .get(`auth/shelter/exist?value=${value}&type=${type}`)
     .then(res => res.json<Promise<Record<'isExist', boolean>>>());
+
+  return response;
+};
+
+export const fowardPwdLink = async (data: fowardPwdPayload) => {
+  const response = await api
+    .post(`auth/shelter/reset-password`, {
+      json: data
+    })
+    .then(res => res.json<fowardPwdResponse>());
 
   return response;
 };

--- a/src/api/shelter/event/useParticipateVolEvent.ts
+++ b/src/api/shelter/event/useParticipateVolEvent.ts
@@ -23,10 +23,7 @@ export default function useParticipateVolEvent(
       participate(shelterId, volunteerEventId),
     {
       onSuccess: (data, variables, context) => {
-        return queryClient.invalidateQueries({
-          queryKey: queryKey.all,
-          refetchType: 'all'
-        });
+        return queryClient.invalidateQueries();
       },
       ...options
     }

--- a/src/api/shelter/event/useWithdrawVolEvent.ts
+++ b/src/api/shelter/event/useWithdrawVolEvent.ts
@@ -22,10 +22,7 @@ export default function useWithdrawVolEvent(
     ({ shelterId, volunteerEventId }) => withdraw(shelterId, volunteerEventId),
     {
       onSuccess: (data, variables, context) => {
-        return queryClient.invalidateQueries({
-          queryKey: queryKey.all,
-          refetchType: 'all'
-        });
+        return queryClient.invalidateQueries();
       },
       ...options
     }

--- a/src/app/admin/shelter/edit/page.tsx
+++ b/src/app/admin/shelter/edit/page.tsx
@@ -118,6 +118,13 @@ export default function ShelterEditPage() {
       </section>
       <section>
         <EditMenu
+          title="비밀번호 변경"
+          caption=""
+          onClick={() => router.push(location.pathname + '/password')}
+        />
+        <Divider spacing={18} />
+
+        <EditMenu
           title="필수 정보"
           caption="보호소 이름 / 연락처 / 주소 / 소개문구"
           titleSuffix={MenuBadge(true)}

--- a/src/app/admin/shelter/edit/password/page.tsx
+++ b/src/app/admin/shelter/edit/password/page.tsx
@@ -1,0 +1,93 @@
+'use client';
+import { pwdChange } from '@/api/shelter/auth/login';
+import { passwordChangeValidatgion } from '@/app/shelter/utils/shelterValidaion';
+import Button from '@/components/common/Button/Button';
+import FormProvider from '@/components/common/FormProvider/FormProvider';
+import TextField from '@/components/common/TextField/TextField';
+import useHeader from '@/hooks/useHeader';
+import useToast from '@/hooks/useToast';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { isEmpty } from 'lodash';
+import { useCallback } from 'react';
+import { useForm } from 'react-hook-form';
+import * as styles from './style.css';
+import { useRouter } from 'next/navigation';
+
+interface PasswordChangePageProps {}
+
+interface PassChangeFormValue {
+  password: string;
+  passwordConfirm: string;
+}
+
+export default function PasswordChangePage({}: PasswordChangePageProps) {
+  useHeader({ title: '비밀번호 변경' });
+  const router = useRouter();
+  const toastOn = useToast();
+
+  const methods = useForm<PassChangeFormValue>({
+    mode: 'all',
+    reValidateMode: 'onChange',
+    resolver: yupResolver(passwordChangeValidatgion)
+  });
+  const {
+    register,
+    formState: { errors },
+    getValues,
+    handleSubmit
+  } = methods;
+
+  const areInputsFilled =
+    Boolean(getValues('password')?.trim()) &&
+    Boolean(getValues('passwordConfirm')?.trim());
+
+  const handlePasswordChange = useCallback(
+    async (data: PassChangeFormValue) => {
+      const newData = {
+        password: data.password
+      };
+
+      try {
+        await pwdChange(newData);
+        toastOn('비밀번호가 변경되었습니다. 홈 화면으로 이동합니다.');
+        router.push('/');
+      } catch (error) {
+        toastOn('알 수 없는 오류가 발생했습니다. 다시 시도해주세요.');
+      }
+    },
+    []
+  );
+
+  return (
+    <div className={styles.container}>
+      <FormProvider
+        methods={methods}
+        onSubmit={handleSubmit(handlePasswordChange)}
+        style={{ display: 'flex', flexDirection: 'column', rowGap: '20px' }}
+      >
+        <TextField
+          label="새 비밀번호"
+          placeholder="영문, 숫자, 특수문자 2가지 조합 8~15자"
+          {...register('password')}
+          type="password"
+          error={errors.password}
+          autoFocus
+        />
+        <TextField
+          label="새 비밀번호 확인"
+          placeholder="새 비밀번호를 한번 더 입력해주세요."
+          {...register('passwordConfirm')}
+          type="password"
+          error={errors.passwordConfirm}
+        />
+        <Button
+          style={{ marginTop: '47px' }}
+          disabled={!isEmpty(errors) || !areInputsFilled}
+          type="submit"
+        >
+          변경하기
+        </Button>
+      </FormProvider>
+    </div>
+  );
+}

--- a/src/app/admin/shelter/edit/password/style.css.ts
+++ b/src/app/admin/shelter/edit/password/style.css.ts
@@ -1,0 +1,8 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  paddingTop: '24px',
+  display: 'flex',
+  flexDirection: 'column',
+  rowGap: '24px'
+});

--- a/src/app/admin/shelter/event/edit/page.tsx
+++ b/src/app/admin/shelter/event/edit/page.tsx
@@ -1,6 +1,17 @@
 'use client';
 
+import useAdminVolunteerEvent from '@/api/shelter/admin/useAdminVolunteerEvent';
+import useUpdateVolunteerEvent from '@/api/shelter/admin/useUpdateVolunteerEvent';
+import {
+  PutVolunteerEventPayload,
+  VolunteerEventPayload,
+  post
+} from '@/api/shelter/admin/volunteer-event';
+import Button from '@/components/common/Button/Button';
 import ChipInput from '@/components/common/ChipInput/ChipInput';
+import FixedFooter from '@/components/common/FixedFooter/FixedFooter';
+import TextArea from '@/components/common/TextField/TextArea';
+import TextField from '@/components/common/TextField/TextField';
 import {
   ButtonText1,
   Caption1,
@@ -14,29 +25,19 @@ import {
   IterationCycle,
   VolunteerEventCategory
 } from '@/constants/volunteerEvent';
-import { useEffect, useMemo, useState } from 'react';
-import * as styles from './styles.css';
-import { useForm } from 'react-hook-form';
+import useHeader from '@/hooks/useHeader';
+import { formatDatetimeForServer } from '@/utils/timeConvert';
 import yup from '@/utils/yup';
 import { yupResolver } from '@hookform/resolvers/yup';
-import TextField from '@/components/common/TextField/TextField';
-import TextArea from '@/components/common/TextField/TextArea';
-import FixedFooter from '@/components/common/FixedFooter/FixedFooter';
-import Button from '@/components/common/Button/Button';
-import moment from 'moment';
-import getMaxOfIterationEndAt from './utils/getMaxOfIterationEndAt';
-import getIterationNotice from './utils/getIterationNotice';
 import { isEmpty } from 'lodash';
-import { formatDatetimeForServer } from '@/utils/timeConvert';
-import {
-  PutVolunteerEventPayload,
-  VolunteerEventPayload,
-  post,
-  put
-} from '@/api/shelter/admin/volunteer-event';
-import useAdminVolunteerEvent from '@/api/shelter/admin/useAdminVolunteerEvent';
+import moment from 'moment';
 import { useRouter } from 'next/navigation';
-import useHeader from '@/hooks/useHeader';
+import { useEffect, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import * as styles from './styles.css';
+import getIterationNotice from './utils/getIterationNotice';
+import getMaxOfIterationEndAt from './utils/getMaxOfIterationEndAt';
+import useWriteVolunteerEvent from '@/api/shelter/admin/useWriteVolunteerEvent';
 
 type ChipValues = {
   category: string;
@@ -220,13 +221,16 @@ export default function ShelterEventEditPage({
     return payload;
   };
 
+  const { mutateAsync: putEvent } = useUpdateVolunteerEvent();
+  const { mutateAsync: postEvent } = useWriteVolunteerEvent();
+
   const onSubmit = async (values: FormValues) => {
     if (initialData) {
       const payload = getPutPayload(values);
-      await put(eventId, payload);
+      await putEvent({ eventId, ...payload });
     } else {
       const payload = getPostPayload(values);
-      await post(payload);
+      await postEvent(payload);
     }
     router.back();
   };

--- a/src/app/api/auth/shelter/login/route.ts
+++ b/src/app/api/auth/shelter/login/route.ts
@@ -4,6 +4,7 @@ import {
   COOKIE_REDIRECT_URL,
   COOKIE_REFRESH_TOKEN_KEY
 } from '@/constants/cookieKeys';
+import { URL_PASSWORD_CHANGE } from '@/constants/landingURL';
 import { decrypt } from '@/utils/passwordCrypto';
 import { getCookieConfig } from '@/utils/token/cookieConfig';
 import { NextRequest, NextResponse } from 'next/server';
@@ -38,7 +39,7 @@ export async function POST(req: NextRequest) {
 
     const cookieConfig = getCookieConfig(req);
     if (needToChangePassword) {
-      res.cookies.set(COOKIE_REDIRECT_URL, '/admin');
+      res.cookies.set(COOKIE_REDIRECT_URL, URL_PASSWORD_CHANGE);
     }
     res.cookies.set(COOKIE_ACCESS_TOKEN_KEY, accessToken, cookieConfig);
     res.cookies.set(COOKIE_REFRESH_TOKEN_KEY, refreshToken, cookieConfig);

--- a/src/app/api/auth/shelter/login/route.ts
+++ b/src/app/api/auth/shelter/login/route.ts
@@ -1,6 +1,7 @@
 import { loginShelter } from '@/api/shelter/auth/login';
 import {
   COOKIE_ACCESS_TOKEN_KEY,
+  COOKIE_REDIRECT_URL,
   COOKIE_REFRESH_TOKEN_KEY
 } from '@/constants/cookieKeys';
 import { decrypt } from '@/utils/passwordCrypto';
@@ -22,10 +23,12 @@ export async function POST(req: NextRequest) {
     if (!email || !password) {
       throw new Error('이메일과 비밀번호를 입력해주세요.');
     }
-    const { accessToken, refreshToken } = await loginShelter({
-      email,
-      password
-    });
+    const { accessToken, refreshToken, needToChangePassword } =
+      await loginShelter({
+        email,
+        password
+      });
+
     const res = NextResponse.json({
       redirectURI: redirectTo,
       success: true,
@@ -34,7 +37,9 @@ export async function POST(req: NextRequest) {
     });
 
     const cookieConfig = getCookieConfig(req);
-
+    if (needToChangePassword) {
+      res.cookies.set(COOKIE_REDIRECT_URL, '/admin');
+    }
     res.cookies.set(COOKIE_ACCESS_TOKEN_KEY, accessToken, cookieConfig);
     res.cookies.set(COOKIE_REFRESH_TOKEN_KEY, refreshToken, cookieConfig);
     return res;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,6 +28,11 @@ export const metadata = {
         alt: '댕글댕글'
       }
     ]
+  },
+  viewport: {
+    width: 'device-width',
+    initialScale: 1,
+    maximumScale: 1
   }
 };
 

--- a/src/app/login/shelter/page.tsx
+++ b/src/app/login/shelter/page.tsx
@@ -34,7 +34,7 @@ export default function ShelterLogin() {
 
   const router = useRouter();
   const toastOn = useToast();
-  const setHeader = useHeader({ title: '보호소 파트너로 시작하기' });
+  useHeader({ title: '보호소 파트너로 시작하기' });
 
   const { logout } = useAuthContext();
   useEffect(logout, [logout]);
@@ -44,11 +44,11 @@ export default function ShelterLogin() {
   const handleLogin = useCallback(
     async (data: LoginPayload) => {
       try {
+        await mutateAsync(data);
         const redirectPath = Cookies.get(COOKIE_REDIRECT_URL) || '';
         const redirectTo = `${location.origin}${decodeURIComponent(
           redirectPath
         )}`;
-        await mutateAsync(data);
         location.href = redirectTo;
       } catch (e) {
         toastOn('로그인에 실패했습니다.');

--- a/src/app/login/shelter/password/page.tsx
+++ b/src/app/login/shelter/password/page.tsx
@@ -10,29 +10,35 @@ import useHeader from '@/hooks/useHeader';
 import useToast from '@/hooks/useToast';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { isEmpty } from 'lodash';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { passWordFindValidation } from '../../../shelter/utils/shelterValidaion';
 import * as styles from './styles.css';
+import FormProvider from '@/components/common/FormProvider/FormProvider';
+import { handlePhoneNumberChange, removeDash } from '@/utils/formatInputs';
+import { fowardPwdLink } from '@/api/shelter/auth/login';
 
 const helperMessage = `등록한 파트너 계정의 이메일을 입력해주세요.
 비밀번호를 재설정할 수 있는 링크를 보내드립니다.`;
 
 interface FindPassFormValue {
   email: string;
+  phoneNumber: string;
 }
 
 export default function ShelterPassword() {
-  const {
-    register,
-    formState: { errors },
-    setError,
-    watch
-  } = useForm<FindPassFormValue>({
+  const methods = useForm<FindPassFormValue>({
     mode: 'all',
     reValidateMode: 'onChange',
     resolver: yupResolver(passWordFindValidation)
   });
+  const {
+    register,
+    formState: { errors },
+    setError,
+    watch,
+    handleSubmit
+  } = methods;
 
   useHeader({ title: '비밀번호 찾기' });
   const toastOn = useToast();
@@ -58,13 +64,19 @@ export default function ShelterPassword() {
     }
   }, [emailValue, debouncedValidator]);
 
-  const handleSendPassLink = async () => {
+  const handleSendPassLink = useCallback(async (data: FindPassFormValue) => {
+    const newData = {
+      ...data,
+      phoneNumber: removeDash(data.phoneNumber)
+    };
+
     try {
+      await fowardPwdLink(newData);
       toastOn('비밀번호 재설정 링크가 발송되었습니다.');
     } catch (error) {
       toastOn('알 수 없는 오류가 발생했습니다. 다시 시도해주세요.');
     }
-  };
+  }, []);
 
   return (
     <>
@@ -74,25 +86,38 @@ export default function ShelterPassword() {
           <Line>등록하신 이메일을 입력해주세요</Line>
         </EmphasizedTitle>
       </div>
-      <TextField
-        helper={helperMessage}
-        placeholder="등록하신 이메일을 입력해주세요."
-        {...register('email')}
-        onBlur={() => {
-          if (emailValue?.length > 0) {
-            debouncedValidator(emailValue, 'EMAIL');
-          }
-        }}
-        error={errors.email}
-        autoFocus
-      />
-      <Button
-        style={{ marginTop: '47px' }}
-        disabled={!isEmpty(errors)}
-        onClick={handleSendPassLink}
+
+      <FormProvider
+        methods={methods}
+        onSubmit={handleSubmit(handleSendPassLink)}
+        style={{ display: 'flex', flexDirection: 'column', rowGap: '20px' }}
       >
-        비밀번호 재설정 링크 보내기
-      </Button>
+        <TextField
+          helper={helperMessage}
+          placeholder="등록하신 이메일을 입력해주세요."
+          {...register('email')}
+          onBlur={() => {
+            if (emailValue?.length > 0) {
+              debouncedValidator(emailValue, 'EMAIL');
+            }
+          }}
+          error={errors.email}
+          autoFocus
+        />
+        <TextField
+          placeholder="등록하신 핸드폰 번호를 입력해주세요. (-제외)"
+          {...register('phoneNumber', { onChange: handlePhoneNumberChange })}
+          error={errors.phoneNumber}
+          autoFocus
+        />
+        <Button
+          style={{ marginTop: '47px' }}
+          disabled={!isEmpty(errors)}
+          type="submit"
+        >
+          비밀번호 재설정 링크 보내기
+        </Button>
+      </FormProvider>
     </>
   );
 }

--- a/src/app/shelter/utils/shelterValidaion.ts
+++ b/src/app/shelter/utils/shelterValidaion.ts
@@ -39,6 +39,25 @@ export const passWordFindValidation = yup.object().shape({
     )
 });
 
+export const passwordChangeValidatgion = yup.object().shape({
+  password: yup
+    .string()
+    .min(8, '비밀번호가 너무 짧습니다. 8~15자로 입력해주세요.')
+    .max(15, '비밀번호가 너무 깁니다. 8~15자로 입력해주세요.')
+    .test(
+      'password',
+      '영문, 숫자, 특수문자 중 2가지 조합으로 8~15자로 입력해주세요.',
+      value => {
+        const matches = checkPwd(value);
+        return matches;
+      }
+    ),
+  passwordConfirm: yup
+    .string()
+    .required()
+    .oneOf([yup.ref('password')], '비밀번호가 일치하지 않습니다.')
+});
+
 export const registerValidation = yup.object({
   email: yup.string().email('올바른 이메일 형식이 아닙니다.'),
   password: yup

--- a/src/app/shelter/utils/shelterValidaion.ts
+++ b/src/app/shelter/utils/shelterValidaion.ts
@@ -8,20 +8,35 @@ export const loginValidation = yup.object().shape({
     .email('올바른 이메일 형식이 아닙니다.'),
   password: yup
     .string()
-    .required()
     .min(8, '비밀번호가 너무 짧습니다. 8~15자로 입력해주세요.')
-    .matches(
-      /(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*])/,
-      '영문, 숫자, 특수문자 3가지 조합 8~15자로 입력해주세요.'
-    )
     .max(15, '비밀번호가 너무 깁니다. 8~15자로 입력해주세요.')
+    .test(
+      'password',
+      '영문, 숫자, 특수문자 중 2가지 조합으로 8~15자로 입력해주세요.',
+      value => {
+        const matches = checkPwd(value);
+        return matches;
+      }
+    )
 });
 
 export const passWordFindValidation = yup.object().shape({
   email: yup
     .string()
     .required('필수항목 입니다.')
-    .email('올바른 이메일 형식이 아닙니다.')
+    .email('올바른 이메일 형식이 아닙니다.'),
+  phoneNumber: yup
+    .string()
+    .required('필수항목 입니다.')
+    .matches(phoneRegex, '숫자만 입력해주세요')
+    .test(
+      'phone-format-validation',
+      '전화번호 형식이 올바르지 않습니다',
+      value => {
+        const matches = checkPhoneNumber(value);
+        return matches;
+      }
+    )
 });
 
 export const registerValidation = yup.object({
@@ -29,11 +44,15 @@ export const registerValidation = yup.object({
   password: yup
     .string()
     .min(8, '비밀번호가 너무 짧습니다. 8~15자로 입력해주세요.')
-    .matches(
-      /(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*])/,
-      '영문, 숫자, 특수문자 3가지 조합 8~15자로 입력해주세요.'
-    )
-    .max(15, '비밀번호가 너무 깁니다. 8~15자로 입력해주세요.'),
+    .max(15, '비밀번호가 너무 깁니다. 8~15자로 입력해주세요.')
+    .test(
+      'password',
+      '영문, 숫자, 특수문자 중 2가지 조합으로 8~15자로 입력해주세요.',
+      value => {
+        const matches = checkPwd(value);
+        return matches;
+      }
+    ),
   passwordConfirm: yup
     .string()
     .optional()
@@ -59,25 +78,8 @@ export const registerValidation = yup.object({
       'phone-format-validation',
       '전화번호 형식이 올바르지 않습니다',
       value => {
-        let val = removeDash(value || '');
-        if (!val || (val && val.length <= 3)) {
-          return true;
-        }
-
-        const result = val.slice(0, 2);
-        const phone = val.slice(2);
-
-        if (result === '02' && (phone.length === 7 || phone.length <= 8)) {
-          return true;
-        } else if (
-          phone.length === 7 ||
-          phone.length === 8 ||
-          phone.length === 9
-        ) {
-          return true;
-        } else {
-          return false;
-        }
+        const matches = checkPhoneNumber(value);
+        return matches;
       }
     ),
   address: yup.object().shape({
@@ -89,3 +91,32 @@ export const registerValidation = yup.object({
   }),
   description: yup.string().max(300, '입력 가능 글자수를 초과했어요.')
 });
+
+const checkPwd = (value?: string) => {
+  if (!value) return false;
+  let matches = 0;
+
+  if (/[a-zA-Z]/.test(value)) matches++;
+  if (/[0-9]/.test(value)) matches++;
+  if (/[!@#$%^&*]/.test(value)) matches++;
+
+  return matches >= 2;
+};
+
+const checkPhoneNumber = (value?: string) => {
+  let val = removeDash(value || '');
+  if (!val || (val && val.length <= 3)) {
+    return true;
+  }
+
+  const result = val.slice(0, 2);
+  const phone = val.slice(2);
+
+  if (result === '02' && (phone.length === 7 || phone.length <= 8)) {
+    return true;
+  } else if (phone.length === 7 || phone.length === 8 || phone.length === 9) {
+    return true;
+  } else {
+    return false;
+  }
+};

--- a/src/components/common/Calendar/DangleCalendar.css.ts
+++ b/src/components/common/Calendar/DangleCalendar.css.ts
@@ -90,7 +90,7 @@ globalStyle(`${calendar} .react-calendar__month-view__weekdays`, {
   fontSize: '12px',
   fontFamily: 'Pretendard',
   fontStyle: 'normal',
-  fontWeight: 500,
+  fontWeight: 700,
   lineHeight: '14px',
   color: '#6c6c6c',
   textAlign: 'center'
@@ -98,7 +98,8 @@ globalStyle(`${calendar} .react-calendar__month-view__weekdays`, {
 
 // 날짜 container
 globalStyle(`${calendar} .react-calendar__month-view__days`, {
-  padding: '0px 12px 0px 12px'
+  padding: '0px 12px 0px 12px',
+  width: '100%'
 });
 
 globalStyle(`${calendar} .react-calendar__tile`, {
@@ -110,7 +111,7 @@ globalStyle(`${calendar} .react-calendar__tile`, {
   fontSize: '12px',
   fontFamily: 'Pretendard',
   fontStyle: 'normal',
-  fontWeight: 500,
+  fontWeight: 600,
   lineHeight: '14px',
   color: '#6c6c6c',
 

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -37,7 +37,8 @@ export default function Header({
   const router = useRouter();
   const pathName = usePathname();
   const navigate = () => {
-    router.back();
+    // 웹페이지 처음 방문 했을 시 window.history.length === 1
+    history.length === 1 ? router.push('/') : router.back();
   };
 
   const headerColor = useMemo(() => {

--- a/src/constants/landingURL.ts
+++ b/src/constants/landingURL.ts
@@ -6,3 +6,4 @@ export const URL_FAQ =
   'https://dankim9494.notion.site/FAQ-2c54d818708f454cb4f094d62c3bd4d0?pvs=4';
 export const URL_SERVICE_INTRODUCTION =
   'https://dankim9494.notion.site/91e59199f72c41c3842320bf2232c3f4?pvs=4';
+export const URL_PASSWORD_CHANGE = '/admin/shelter/edit/password';

--- a/src/utils/formatInputs.ts
+++ b/src/utils/formatInputs.ts
@@ -29,3 +29,10 @@ export function formatPhone(input: string) {
 export function removeDash(input: string) {
   return input.replace(/-/g, '');
 }
+
+export const handlePhoneNumberChange = (
+  event: React.ChangeEvent<HTMLInputElement>
+) => {
+  const value = event.target.value;
+  event.target.value = formatPhone(value);
+};

--- a/src/utils/middleware/headerServerSideRenderProp.ts
+++ b/src/utils/middleware/headerServerSideRenderProp.ts
@@ -22,6 +22,10 @@ export const headerServerSideRenderProp: HeaderServerSideRenderProp[] = [
     title: '비밀번호 찾기'
   },
   {
+    url: '/admin/shelter/edit/password',
+    title: '비밀번호 변경'
+  },
+  {
     url: '/register/shelter',
     title: '보호소 파트너 계정 가입'
   },


### PR DESCRIPTION
## Motivation

- [YW2-234](https://yapp22-web2.atlassian.net/jira/software/projects/YW2/boards/3/timeline?selectedIssue=YW2-234)


- 하기 QA 추가로 반영하였습니다.
  - [홈>캘린더 영역 내 UI 폰트 사이즈 작게 보임](https://www.notion.so/dankim9494/35d6d811e39e42a3809ae068530c6c11?v=59891bd4b0cf4e75ac22273c0d5e9a84&p=89594ea7756b403c90e98dcfa55c22b3&pm=c)
  - [공유하기 통해 링크 공유 > 링크 선택하여 페이지 열림> 페이지 내 뒤로가기 선택 시 동작 없음](https://www.notion.so/dankim9494/35d6d811e39e42a3809ae068530c6c11?v=59891bd4b0cf4e75ac22273c0d5e9a84&p=f52fcdacd052473fb954b39db9f9d8c6&pm=c)

### Key Changes

- **비밀번호 찾기 링크** 클릭 시 변경된 비밀번호를 해당 이메일로 보냅니다.
- 비밀번호가 변경 된 후 **최초 로그인 시**에 **비밀번호 변경 페이지로 랜딩**됩니다.
- **보호소 정보 페이지**에 비밀번호 변경 페이지 랜딩되는 섹션이 추가되었습니다.
- 봉사 생성/수정/삭제/신청/철회 시 **홈 화면, 보호소 홈, 어드민에서 이용되는 리스트 API가 모두 refetch** 되어야 하는 이슈가 있어 수정한 부분이 존재합니다.